### PR TITLE
Enable only XML Jacoco report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,3 +59,11 @@ sonarqube {
     property "sonar.host.url", "https://sonarcloud.io"
   }
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        csv.enabled false
+        html.enabled false
+    }
+}


### PR DESCRIPTION
This is the only format required by Sonar.