### PR TITLE
Fix incorrect version name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'posmy'
-version = '0.0.1-SNAPSHOT'
+version = '20.1.0-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {


### PR DESCRIPTION
In order to align with our Milestone. Version should be
presented as YY.<release>.<bug-fix>.

Fixes gh-12.