### PR TITLE
Remove developmentOnly configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,6 @@ version = '20.1.0-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
-    developmentOnly
-    runtimeClasspath {
-        extendsFrom developmentOnly
-    }
     compileOnly {
         extendsFrom annotationProcessor
     }


### PR DESCRIPTION
This will be automatically configured by Spring Boot's Gradle plugin.

Closes gh-46.