### PR TITLE
Configure max hour for a desk to be occupied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'com.microsoft.azure:azure-active-directory-spring-boot-starter'
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }

--- a/src/main/java/posmy/argos/desk/context/DeskProperties.java
+++ b/src/main/java/posmy/argos/desk/context/DeskProperties.java
@@ -1,6 +1,7 @@
 package posmy.argos.desk.context;
 
-import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
@@ -9,12 +10,14 @@ import org.springframework.boot.context.properties.ConstructorBinding;
  */
 @ConstructorBinding
 @ConfigurationProperties("argos.desk")
-@Value
+@AllArgsConstructor
+@Getter
 public class DeskProperties {
 
     Period period;
 
-    @Value
+    @AllArgsConstructor
+    @Getter
     public static class Period {
 
         Integer maxHour;

--- a/src/main/java/posmy/argos/desk/context/DeskProperties.java
+++ b/src/main/java/posmy/argos/desk/context/DeskProperties.java
@@ -14,17 +14,10 @@ public class DeskProperties {
 
     Period period;
 
+    @Value
     public static class Period {
 
-        private final Integer maxHour;
-
-        public Period(Integer maxHour) {
-            this.maxHour = maxHour;
-        }
-
-        public Integer getMaxHour() {
-            return maxHour;
-        }
+        Integer maxHour;
 
     }
 

--- a/src/main/java/posmy/argos/desk/context/DeskProperties.java
+++ b/src/main/java/posmy/argos/desk/context/DeskProperties.java
@@ -1,0 +1,31 @@
+package posmy.argos.desk.context;
+
+import lombok.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+/**
+ * @author Rashidi Zin
+ */
+@ConstructorBinding
+@ConfigurationProperties("argos.desk")
+@Value
+public class DeskProperties {
+
+    Period period;
+
+    public static class Period {
+
+        private final Integer maxHour;
+
+        public Period(Integer maxHour) {
+            this.maxHour = maxHour;
+        }
+
+        public Integer getMaxHour() {
+            return maxHour;
+        }
+
+    }
+
+}

--- a/src/main/java/posmy/argos/desk/context/DeskPropertiesConfiguration.java
+++ b/src/main/java/posmy/argos/desk/context/DeskPropertiesConfiguration.java
@@ -1,0 +1,13 @@
+package posmy.argos.desk.context;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Rashidi Zin
+ */
+@Configuration
+@EnableConfigurationProperties(DeskProperties.class)
+public class DeskPropertiesConfiguration {
+
+}

--- a/src/main/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandler.java
+++ b/src/main/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandler.java
@@ -3,6 +3,7 @@ package posmy.argos.desk.event.handler;
 import lombok.AllArgsConstructor;
 import org.springframework.data.rest.core.annotation.HandleAfterSave;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import posmy.argos.desk.context.DeskProperties;
 import posmy.argos.desk.domain.Desk;
 import posmy.argos.desk.domain.DeskStatus;
 import posmy.argos.desk.history.domain.DeskOccupiedHistory;
@@ -23,6 +24,8 @@ public class DeskAfterSaveEventHandler {
 
     private final DeskOccupiedHistoryRepository historyRepository;
 
+    private final DeskProperties properties;
+
     @HandleAfterSave
     void createHistoryInformation(Desk source) {
 
@@ -33,7 +36,7 @@ public class DeskAfterSaveEventHandler {
         var location = source.location();
         var occupant = getLoggedInUsername();
         var since = now();
-        var end = since.plus(9, HOURS);
+        var end = since.plus(properties.getPeriod().getMaxHour(), HOURS);
 
         var history = new DeskOccupiedHistory().location(location).occupant(occupant).since(since).end(end);
 

--- a/src/main/java/posmy/argos/desk/event/handler/DeskEventHandlerConfiguration.java
+++ b/src/main/java/posmy/argos/desk/event/handler/DeskEventHandlerConfiguration.java
@@ -2,6 +2,7 @@ package posmy.argos.desk.event.handler;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import posmy.argos.desk.context.DeskProperties;
 import posmy.argos.desk.history.domain.DeskOccupiedHistoryRepository;
 
 /**
@@ -21,8 +22,8 @@ public class DeskEventHandlerConfiguration {
     }
 
     @Bean("deskAfterSaveEventHandler")
-    public DeskAfterSaveEventHandler afterSave(DeskOccupiedHistoryRepository historyRepository) {
-        return new DeskAfterSaveEventHandler(historyRepository);
+    public DeskAfterSaveEventHandler afterSave(DeskOccupiedHistoryRepository historyRepository, DeskProperties properties) {
+        return new DeskAfterSaveEventHandler(historyRepository, properties);
     }
 
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "argos.desk.period.max-hour",
+      "type": "java.lang.String",
+      "description": "Number of hour to be allocated when desk is occupied."
+    }
+  ]
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
+argos:
+  desk:
+    period:
+      max-hour: 9
+
 azure:
   activedirectory:
     session-stateless: true

--- a/src/test/java/posmy/argos/desk/context/DeskPropertiesConfigurationTests.java
+++ b/src/test/java/posmy/argos/desk/context/DeskPropertiesConfigurationTests.java
@@ -1,0 +1,23 @@
+package posmy.argos.desk.context;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Rashidi Zin
+ */
+@SpringBootTest(properties = "argos.desk.period.max-hour=2", classes = DeskPropertiesConfiguration.class)
+class DeskPropertiesConfigurationTests {
+
+    @Autowired
+    private DeskProperties properties;
+
+    @Test
+    void maxHour() {
+        assertThat(properties.getPeriod().getMaxHour()).isEqualTo(2);
+    }
+
+}

--- a/src/test/java/posmy/argos/desk/domain/DeskRepositoryRestResourceTests.java
+++ b/src/test/java/posmy/argos/desk/domain/DeskRepositoryRestResourceTests.java
@@ -36,7 +36,7 @@ import static posmy.argos.desk.helper.DeskTestHelper.create;
 /**
  * @author Rashidi Zin
  */
-@SpringBootTest
+@SpringBootTest(properties = "argos.desk.period.max-hour=2")
 @WithAzureADUser
 class DeskRepositoryRestResourceTests {
 

--- a/src/test/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandlerTests.java
+++ b/src/test/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandlerTests.java
@@ -10,6 +10,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import posmy.argos.desk.context.DeskProperties;
+import posmy.argos.desk.context.DeskProperties.Period;
 import posmy.argos.desk.domain.Desk;
 import posmy.argos.desk.domain.DeskLocation;
 import posmy.argos.desk.history.domain.DeskOccupiedHistory;
@@ -34,7 +36,9 @@ class DeskAfterSaveEventHandlerTests {
 
     private final DeskOccupiedHistoryRepository historyRepository = mock(DeskOccupiedHistoryRepository.class);
 
-    private final DeskAfterSaveEventHandler handler = new DeskAfterSaveEventHandler(historyRepository);
+    private final DeskProperties properties = new DeskProperties(new Period(9));;
+
+    private final DeskAfterSaveEventHandler handler = new DeskAfterSaveEventHandler(historyRepository, properties);
 
     @BeforeAll
     static void registerUserContext() {


### PR DESCRIPTION
Current implementation hard coded number of hours a desk can be
occupied to nine hours. This may cause some difficulty if application
users want to define them based on their need.

This commit allows the hour to be configured via
`argos.desk.period.max-hour`.

Closes gh-55.