### PR TITLE
Add flexibility for desk max period configuration

### DIFF
--- a/src/main/java/posmy/argos/desk/context/DeskProperties.java
+++ b/src/main/java/posmy/argos/desk/context/DeskProperties.java
@@ -5,23 +5,17 @@ import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
+import java.time.Duration;
+
 /**
  * @author Rashidi Zin
  */
 @ConstructorBinding
 @ConfigurationProperties("argos.desk")
 @AllArgsConstructor
-@Getter
 public class DeskProperties {
 
-    Period period;
-
-    @AllArgsConstructor
     @Getter
-    public static class Period {
-
-        Integer maxHour;
-
-    }
+    private final Duration maxDuration;
 
 }

--- a/src/main/java/posmy/argos/desk/domain/DeskLocation.java
+++ b/src/main/java/posmy/argos/desk/domain/DeskLocation.java
@@ -2,15 +2,15 @@ package posmy.argos.desk.domain;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+import java.util.Objects;
+
 /**
  * @author Rashidi Zin
  */
-@EqualsAndHashCode
 @Accessors(fluent = true)
 @Setter(onMethod = @__(@JsonSetter))
 @Getter(onMethod = @__(@JsonGetter))
@@ -19,5 +19,17 @@ public class DeskLocation {
     String row;
 
     Integer column;
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (!(obj instanceof DeskLocation)) {
+            return false;
+        }
+
+        var other = (DeskLocation) obj;
+
+        return Objects.equals(row, other.row) && Objects.equals(column, other.column);
+    }
 
 }

--- a/src/main/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandler.java
+++ b/src/main/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandler.java
@@ -36,7 +36,7 @@ public class DeskAfterSaveEventHandler {
         var location = source.location();
         var occupant = getLoggedInUsername();
         var since = now();
-        var end = since.plus(properties.getPeriod().getMaxHour(), HOURS);
+        var end = since.plus(properties.getMaxDuration().toHours(), HOURS);
 
         var history = new DeskOccupiedHistory().location(location).occupant(occupant).since(since).end(end);
 

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,9 +1,10 @@
 {
   "properties": [
     {
-      "name": "argos.desk.period.max-hour",
+      "name": "argos.desk.max-duration",
       "type": "java.lang.String",
-      "description": "Number of hour to be allocated when desk is occupied."
+      "description": "Default length of duration allowed for a desk to be occupied.",
+      "defaultValue": "9H"
     }
   ]
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 argos:
   desk:
-    period:
-      max-hour: 9
+    max-duration: 9H
 
 azure:
   activedirectory:

--- a/src/test/java/posmy/argos/desk/context/DeskPropertiesConfigurationTests.java
+++ b/src/test/java/posmy/argos/desk/context/DeskPropertiesConfigurationTests.java
@@ -1,23 +1,46 @@
 package posmy.argos.desk.context;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.core.env.StandardEnvironment;
 
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static java.util.concurrent.TimeUnit.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Rashidi Zin
  */
-@SpringBootTest(properties = "argos.desk.period.max-hour=2", classes = DeskPropertiesConfiguration.class)
+@SpringBootTest(classes = DeskPropertiesConfiguration.class)
 class DeskPropertiesConfigurationTests {
 
     @Autowired
-    private DeskProperties properties;
+    private StandardEnvironment env;
 
-    @Test
-    void maxHour() {
-        assertThat(properties.getPeriod().getMaxHour()).isEqualTo(2);
+    private final static String MAX_DURATION_PROPERTY = "argos.desk.max-duration";
+
+    @ParameterizedTest
+    @MethodSource("maxDurationValues")
+    void maxDuration(String value, long expectedSeconds) {
+        TestPropertyValues.of(String.format("%s=%s", MAX_DURATION_PROPERTY, value)).applyTo(env);
+
+        assertThat(env.getProperty(MAX_DURATION_PROPERTY, Duration.class))
+                .isNotNull()
+                .extracting(Duration::getSeconds)
+                .isEqualTo(expectedSeconds);
     }
 
+    private static Stream<Arguments> maxDurationValues() {
+        return Stream.of(
+                Arguments.of("30M", MINUTES.toSeconds(30)), // Assign by minutes
+                Arguments.of("9H", HOURS.toSeconds(9)), // Assign by hours
+                Arguments.of("7D", DAYS.toSeconds(7)) // Assign by days
+        );
+    }
 }

--- a/src/test/java/posmy/argos/desk/domain/DeskRepositoryRestResourceTests.java
+++ b/src/test/java/posmy/argos/desk/domain/DeskRepositoryRestResourceTests.java
@@ -36,7 +36,7 @@ import static posmy.argos.desk.helper.DeskTestHelper.create;
 /**
  * @author Rashidi Zin
  */
-@SpringBootTest(properties = "argos.desk.period.max-hour=2")
+@SpringBootTest
 @WithAzureADUser
 class DeskRepositoryRestResourceTests {
 

--- a/src/test/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandlerTests.java
+++ b/src/test/java/posmy/argos/desk/event/handler/DeskAfterSaveEventHandlerTests.java
@@ -11,12 +11,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import posmy.argos.desk.context.DeskProperties;
-import posmy.argos.desk.context.DeskProperties.Period;
 import posmy.argos.desk.domain.Desk;
 import posmy.argos.desk.domain.DeskLocation;
 import posmy.argos.desk.history.domain.DeskOccupiedHistory;
 import posmy.argos.desk.history.domain.DeskOccupiedHistoryRepository;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,7 +36,7 @@ class DeskAfterSaveEventHandlerTests {
 
     private final DeskOccupiedHistoryRepository historyRepository = mock(DeskOccupiedHistoryRepository.class);
 
-    private final DeskProperties properties = new DeskProperties(new Period(9));;
+    private final DeskProperties properties = new DeskProperties(Duration.ofHours(9));
 
     private final DeskAfterSaveEventHandler handler = new DeskAfterSaveEventHandler(historyRepository, properties);
 


### PR DESCRIPTION
Previous implementation restricts configuration for max period for a
desk can be occupied can only be done in hours. This will be
challenging if users decided to define them by minutes or days.

This commit allows the configuration to be defined in more flexible
manner. Examples:

  - 30M - 30 minutes
  - 9H - 9 hours
  - 7D - 7 days

Closes gh-59.