### PR TITLE
Remove unnecessary public modifier

### DIFF
--- a/src/test/java/posmy/argos/desk/scheduler/DeskSchedulerIntegrationTests.java
+++ b/src/test/java/posmy/argos/desk/scheduler/DeskSchedulerIntegrationTests.java
@@ -27,7 +27,7 @@ import static org.awaitility.Awaitility.await;
  */
 @SpringBootTest
 @TestPropertySource(properties = { "argos.desk.max-duration=1M", "argos.desk.scheduler-delay=10000" })
-public class DeskSchedulerIntegrationTests {
+class DeskSchedulerIntegrationTests {
 
     @Autowired
     private DeskRepository repository;

--- a/src/test/java/posmy/argos/desk/scheduler/DeskSchedulerServiceTests.java
+++ b/src/test/java/posmy/argos/desk/scheduler/DeskSchedulerServiceTests.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.verify;
  * @author Rashidi Zin
  */
 @ExtendWith(MockitoExtension.class)
-public class DeskSchedulerServiceTests {
+class DeskSchedulerServiceTests {
 
     private final DeskRepository repository = mock(DeskRepository.class);
 

--- a/src/test/java/posmy/argos/desk/scheduler/UpdateDeskStatusSchedulerTests.java
+++ b/src/test/java/posmy/argos/desk/scheduler/UpdateDeskStatusSchedulerTests.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
  * @author Rashidi Zin
  */
 @ExtendWith(MockitoExtension.class)
-public class UpdateDeskStatusSchedulerTests {
+class UpdateDeskStatusSchedulerTests {
 
     private final DeskRepository repository = mock(DeskRepository.class);
 


### PR DESCRIPTION
JUnit Jupiter don't require a test class to be mark as `public`.