### PR TITLE
Remove Dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 The observer.
 
 ## Badges
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=rashidi/argos)](https://dependabot.com) 
 ![Gradle Build](https://github.com/rashidi/argos/workflows/Gradle%20Build/badge.svg) 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rashidi_argos&metric=alert_status)](https://sonarcloud.io/dashboard?id=rashidi_argos) 
 [![codecov](https://codecov.io/gh/rashidi/argos/branch/master/graph/badge.svg)](https://codecov.io/gh/rashidi/argos) 


### PR DESCRIPTION
After migrating Dependabot configuration to Github, the badge is not valid.