### PR TITLE
Fix broken Dependabot auto merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
 - package-ecosystem: gradle
   directory: "/"
+  default_labels: "automated"
   schedule:
     interval: daily
     time: '21:00'


### PR DESCRIPTION
Commit 42c4c16 9 missed to label Dependabot's Pull Requests with "automated" which indicate
that it is automatically created and can be merged automatically too.

See gh-108.